### PR TITLE
Add support for walking a custom-ordered subset of filesystem paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ config.json
 vendor/re2/obj/libre2.a
 /bazel-*
 compile_commands.json
+.devbox

--- a/doc/examples/livegrep/generate_ordered_contents.sh
+++ b/doc/examples/livegrep/generate_ordered_contents.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# A simple example script for sorting paths in a directory to be indexed according to
+# their relevance. This can be used to help populate the ordered-contents field in
+# the fs_paths entry JSON.
+
+if [ -z "$1" ]
+then
+    echo 'usage: generate_ordered_contents.sh DIRECTORY'
+    exit 2
+fi
+
+cd "$1"
+
+find . -type f | awk '
+         {score = 100}
+  /test/ {score -= 10}
+  /BUILD/ {score -= 5}
+        {print score, $0}
+' | sort -k1nr | sed 's/^[-0-9]* //'

--- a/doc/examples/livegrep/index_with_ordered_contents.json
+++ b/doc/examples/livegrep/index_with_ordered_contents.json
@@ -4,11 +4,7 @@
         {
             "name": "livegrep/livegrep",
             "path": "src/",
-            "ordered-contents": [
-                "./codesearch.cc",
-                "./codesearch.h",
-                "./BUILD",
-            ],
+            "ordered-contents": "ordered-contents.txt",
             "metadata": {
                 "url-pattern": "https://github.com/{name}/blob/HEAD/src/{path}#L{lno}"
             }

--- a/doc/examples/livegrep/index_with_ordered_contents.json
+++ b/doc/examples/livegrep/index_with_ordered_contents.json
@@ -1,0 +1,17 @@
+{
+    "name": "livegrep",
+    "fs_paths": [
+        {
+            "name": "livegrep/livegrep",
+            "path": "src/",
+            "ordered-contents": [
+                "./codesearch.cc",
+                "./codesearch.h",
+                "./BUILD",
+            ],
+            "metadata": {
+                "url-pattern": "https://github.com/{name}/blob/HEAD/src/{path}#L{lno}"
+            }
+        }
+    ],
+}

--- a/doc/examples/livegrep/ordered-contents.txt
+++ b/doc/examples/livegrep/ordered-contents.txt
@@ -1,0 +1,3 @@
+./codesearch.cc
+./codesearch.h
+./BUILD

--- a/src/fs_indexer.cc
+++ b/src/fs_indexer.cc
@@ -31,13 +31,20 @@ void fs_indexer::read_file(const fs::path& path) {
     cs_->index_file(tree_, relpath.string(), StringPiece(static_cast<stringstream const&>(stringstream() << in.rdbuf()).str().c_str(), fs::file_size(path)));
 }
 
-void fs_indexer::walk(const vector<string>& ordered_contents) {
-    for (const string& input_path : ordered_contents) {
-        read_file(fs::path(repopath_) / input_path);
+void fs_indexer::walk_contents_file(const fs::path& contents_file_path) {
+    ifstream contents_file(contents_file_path.c_str(), ios::in);
+    if (!contents_file.is_open()) {
+        throw std::ifstream::failure("Unable to open contents file for reading");
+    }
+    string path;
+    while (std::getline(contents_file, path)) {
+        if (path.length()) {
+            read_file(fs::path(repopath_) / path);
+        }
     }
 }
 
-void fs_indexer::walk(const string& path) {
+void fs_indexer::walk(const fs::path& path) {
     static int recursion_depth = 0;
     RecursionCounter guard(recursion_depth);
     if (recursion_depth > kMaxRecursion)
@@ -49,7 +56,7 @@ void fs_indexer::walk(const string& path) {
                 itr != end_itr;
                 ++itr) {
             if (fs::is_directory(itr->status()) ) {
-                fs_indexer::walk(itr->path().c_str());
+                fs_indexer::walk(itr->path());
             } else if (fs::is_regular_file(itr->status()) ) {
                 fs_indexer::read_file(itr->path());
             }

--- a/src/fs_indexer.cc
+++ b/src/fs_indexer.cc
@@ -34,7 +34,7 @@ void fs_indexer::read_file(const fs::path& path) {
 void fs_indexer::walk_contents_file(const fs::path& contents_file_path) {
     ifstream contents_file(contents_file_path.c_str(), ios::in);
     if (!contents_file.is_open()) {
-        throw std::ifstream::failure("Unable to open contents file for reading");
+        throw std::ifstream::failure("Unable to open contents file for reading: " + contents_file_path.string());
     }
     string path;
     while (std::getline(contents_file, path)) {

--- a/src/fs_indexer.h
+++ b/src/fs_indexer.h
@@ -12,6 +12,7 @@
 
 class code_searcher;
 struct indexed_tree;
+namespace boost { namespace filesystem { class path; } }
 
 class fs_indexer {
 public:
@@ -20,13 +21,15 @@ public:
                const string& name,
                json_object *metadata = 0);
     ~fs_indexer();
-    void read_file(const std::string& path);
+    void walk(const std::vector<std::string>& ordered_contents);
     void walk(const std::string& path);
 protected:
     code_searcher *cs_;
     std::string repopath_;
     std::string name_;
     const indexed_tree *tree_;
+
+    void read_file(const boost::filesystem::path& path);
 };
 
 #endif

--- a/src/fs_indexer.h
+++ b/src/fs_indexer.h
@@ -21,8 +21,8 @@ public:
                const string& name,
                json_object *metadata = 0);
     ~fs_indexer();
-    void walk(const std::vector<std::string>& ordered_contents);
-    void walk(const std::string& path);
+    void walk(const boost::filesystem::path& path);
+    void walk_contents_file(const boost::filesystem::path& contents_file_path);
 protected:
     code_searcher *cs_;
     std::string repopath_;

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -92,7 +92,13 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "Walking path_spec name=%s, path=%s\n",
                 it->name.c_str(), it->path.c_str());
         fs_indexer indexer(cs, it->path, it->name, it->metadata);
-        indexer.walk(it->path);
+        if (it->ordered_contents.empty()) {
+            fprintf(stderr, "  walking full tree\n");
+            indexer.walk(it->path);
+        } else {
+            fprintf(stderr, "  walking %zu paths from ordered contents list\n", it->ordered_contents.size());
+            indexer.walk(it->ordered_contents);
+        }
         fprintf(stderr, "done\n");
     }
 

--- a/src/tools/codesearch.cc
+++ b/src/tools/codesearch.cc
@@ -36,6 +36,7 @@
 #include <gflags/gflags.h>
 
 #include <boost/bind.hpp>
+#include <boost/filesystem.hpp>
 #include "re2/regexp.h"
 #include "re2/walker-inl.h"
 
@@ -54,6 +55,7 @@ DEFINE_bool(reload_rpc, false, "Enable the Reload RPC");
 
 using namespace std;
 using namespace re2;
+namespace fs = boost::filesystem;
 
 using grpc::Server;
 using grpc::ServerBuilder;
@@ -69,7 +71,8 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         exit(1);
     }
 
-    json_object *obj = json_object_from_file(const_cast<char*>(argv[1].c_str()));
+    fs::path config_file_path(argv[1]);
+    json_object *obj = json_object_from_file(config_file_path.c_str());
     if (is_error(obj)) {
         fprintf(stderr, "Error parsing `%s'\n",
                 argv[1].c_str());
@@ -92,12 +95,13 @@ void build_index(code_searcher *cs, const vector<std::string> &argv) {
         fprintf(stderr, "Walking path_spec name=%s, path=%s\n",
                 it->name.c_str(), it->path.c_str());
         fs_indexer indexer(cs, it->path, it->name, it->metadata);
-        if (it->ordered_contents.empty()) {
+        if (it->ordered_contents_file_path.empty()) {
             fprintf(stderr, "  walking full tree\n");
             indexer.walk(it->path);
         } else {
-            fprintf(stderr, "  walking %zu paths from ordered contents list\n", it->ordered_contents.size());
-            indexer.walk(it->ordered_contents);
+            fprintf(stderr, "  walking paths from ordered contents list\n");
+            fs::path contents_file_path = fs::canonical(it->ordered_contents_file_path, config_file_path.remove_filename());
+            indexer.walk_contents_file(contents_file_path);
         }
         fprintf(stderr, "done\n");
     }

--- a/src/tools/transport.cc
+++ b/src/tools/transport.cc
@@ -80,6 +80,8 @@ json_parse_error parse_object(json_object *js, path_spec *p) {
     err = parse_object(js, "name", &p->name);
     if (!err.ok()) return err;
     err = parse_object(js, "metadata", &p->metadata);
+    if (!err.ok()) return err;
+    err = parse_object(js, "ordered-contents", &p->ordered_contents);
     return err;
 }
 

--- a/src/tools/transport.cc
+++ b/src/tools/transport.cc
@@ -81,7 +81,7 @@ json_parse_error parse_object(json_object *js, path_spec *p) {
     if (!err.ok()) return err;
     err = parse_object(js, "metadata", &p->metadata);
     if (!err.ok()) return err;
-    err = parse_object(js, "ordered-contents", &p->ordered_contents);
+    err = parse_object(js, "ordered-contents", &p->ordered_contents_file_path);
     return err;
 }
 

--- a/src/tools/transport.h
+++ b/src/tools/transport.h
@@ -18,6 +18,7 @@ struct json_object;
 struct path_spec {
     std::string path;
     std::string name;
+    std::vector<std::string> ordered_contents;
     json_object *metadata;
 
     path_spec() : metadata(NULL) {}

--- a/src/tools/transport.h
+++ b/src/tools/transport.h
@@ -18,7 +18,7 @@ struct json_object;
 struct path_spec {
     std::string path;
     std::string name;
-    std::vector<std::string> ordered_contents;
+    std::string ordered_contents_file_path;
     json_object *metadata;
 
     path_spec() : metadata(NULL) {}


### PR DESCRIPTION
This PR adds an optional `ordered_contents` input to the filesystem path indexer. If `ordered_contents` is provided and non-empty, the indexer will index its contents rather than manually walking the directory tree. This allows users to control the order that files show up in the search results by using arbitrarily complex sorting/ranking rules.

Currently, if the `ordered_contents` contains invalid paths (e.g. paths that don't actually exist), indexing will fast-fail with an error.