### PR TITLE
added a new endpoint that allows quick querying from the address bar

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -67,6 +67,10 @@ func (s *server) loadTemplates() {
 	}
 }
 
+func (s *server) ServeFastSearch(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/search/?q=" + r.URL.Query().Get(":query"), 303)
+}
+
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.inner.ServeHTTP(w, r)
 }
@@ -555,6 +559,7 @@ func New(cfg *config.Config) (http.Handler, error) {
 
 	m.Add("GET", "/api/v1/search/:backend", srv.Handler(srv.ServeAPISearch))
 	m.Add("GET", "/api/v1/search/", srv.Handler(srv.ServeAPISearch))
+  m.Add("GET", "/:query/", srv.Handler(srv.ServeFastSearch))
 
 	var h http.Handler = m
 


### PR DESCRIPTION
added a new endpoint that allows quick querying from the address bar

if a top level get request ending in a / does not match any endpoint it automatically makes a search instead. most browsers also support spaces

e.g. code/hello world/ searches "hello world"