### PR TITLE
Fix the logic that resets the patch range that's too large in analyzeEditAndMapLine

### DIFF
--- a/server/fastforward.go
+++ b/server/fastforward.go
@@ -65,13 +65,13 @@ func analyzeEditAndMapLine(source_lines, target_lines []string, source_lineno in
 	if len(source_lines) > SOURCE_CHUNK_MAX_CONTEXT {
 		// HAX(jongmin): Constraint the # of source lines we run on to avoid quadratic runtime.
 		new_start := max(source_lineno-(SOURCE_CHUNK_MAX_CONTEXT/2), 1)
-		new_end := new_start + SOURCE_CHUNK_MAX_CONTEXT - 1
+		new_end := new_start + SOURCE_CHUNK_MAX_CONTEXT // exclusive
 		if new_end > len(source_lines) {
-			new_start = max(len(source_lines)-SOURCE_CHUNK_MAX_CONTEXT+1, 1)
-			new_end = len(source_lines)
+			new_end = len(source_lines) + 1
+			new_start = max(new_end - SOURCE_CHUNK_MAX_CONTEXT, 1)
 		}
 		new_source_lineno := source_lineno - new_start + 1
-		return analyzeEditAndMapLine(source_lines[new_start-1:new_end], target_lines, new_source_lineno)
+		return analyzeEditAndMapLine(source_lines[new_start-1:new_end-1], target_lines, new_source_lineno)
 	}
 	source_chars := strings.Join(source_lines, "\n")
 	target_chars := strings.Join(target_lines, "\n")

--- a/server/fastforward.go
+++ b/server/fastforward.go
@@ -65,13 +65,13 @@ func analyzeEditAndMapLine(source_lines, target_lines []string, source_lineno in
 	if len(source_lines) > SOURCE_CHUNK_MAX_CONTEXT {
 		// HAX(jongmin): Constraint the # of source lines we run on to avoid quadratic runtime.
 		new_start := max(source_lineno-(SOURCE_CHUNK_MAX_CONTEXT/2), 1)
-		new_end := new_start + SOURCE_CHUNK_MAX_CONTEXT
+		new_end := new_start + SOURCE_CHUNK_MAX_CONTEXT - 1
 		if new_end > len(source_lines) {
-			new_start = max(len(source_lines)+SOURCE_CHUNK_MAX_CONTEXT, 1)
+			new_start = max(len(source_lines)-SOURCE_CHUNK_MAX_CONTEXT+1, 1)
 			new_end = len(source_lines)
 		}
 		new_source_lineno := source_lineno - new_start + 1
-		return analyzeEditAndMapLine(source_lines[new_start-1:new_end-1], target_lines, new_source_lineno)
+		return analyzeEditAndMapLine(source_lines[new_start-1:new_end], target_lines, new_source_lineno)
 	}
 	source_chars := strings.Join(source_lines, "\n")
 	target_chars := strings.Join(target_lines, "\n")

--- a/server/fastforward_test.go
+++ b/server/fastforward_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -30,6 +31,10 @@ func TestAnalyzeEditAndMapLine(t *testing.T) {
 		"}",
 	}
 	lines2 := []string{""}
+
+	// Regression test for OOB error in case of a really long patch
+	lines3 := append(lines0[:1], append(make([]string, 100), lines0[1:]...)...)
+
 	var cases = []struct {
 		source_lines   []string
 		target_lines   []string
@@ -55,7 +60,8 @@ func TestAnalyzeEditAndMapLine(t *testing.T) {
 		{lines1, lines0, 7, "9"},
 		{lines1, lines0, 8, "9"}, // deleted line
 		{lines1, lines0, 9, "10"},
-		{lines0, lines2, 1, "1"},   // regression test
+		{lines0, lines2, 1, "1"},                                 // regression test
+		{lines3, lines0, len(lines3), strconv.Itoa(len(lines0))}, // regression test
 	}
 	for _, testCase := range cases {
 		target_lineno, err := analyzeEditAndMapLine(testCase.source_lines, testCase.target_lines, testCase.source_lineno)


### PR DESCRIPTION
This fixes a silly bug that triggered in case the patch was too large, that was not discovered because there was no test coverage for the particular code path. The bug involved a flipped sign (that made `new_start` larger than `new_end`) and some off-by-one errors owing to the fact that line numbers are 1-indexed and it's not clear in the code whether a range is inclusive/exclusive. Added a test to catch those.