### PR TITLE
Fix FileBlameWithStart to properly attribute unchanged lines to the start commit

### DIFF
--- a/blameworthy/indexer.go
+++ b/blameworthy/indexer.go
@@ -86,7 +86,10 @@ func (history GitHistory) FileBlameWithStart(start_commit, target_commit, path s
 
 	// Get the starting line count of the file.
 	initial_line_count := fileHistory[indices[0]-1].LineCountAfter
-	segments := BlameSegments{{initial_line_count, 1, fileHistory[indices[0]-1].Commit}}
+	// Synthesize a Commit struct to pretend that we have a commit at `start_commit`.
+	anchor_commit := *fileHistory[indices[0]-1].Commit
+	anchor_commit.Hash = start_commit
+	segments := BlameSegments{{initial_line_count, 1, &anchor_commit}}
 	for i := indices[0]; i < indices[1]; i++ {
 		segments = fileHistory[i].step(segments)
 	}


### PR DESCRIPTION
Currently `FileBlameWithStart` will initialize the blame info to point to the latest commit on the file as of `start_commit`. To be correct w.r.t. the docstring,  it should initialize the blame info to point to `start_commit`.

This means that if you currently try to fast-forward from an old commit that didn't touch the file in question, and the line was not modified later, you'd get bad indices.